### PR TITLE
Add missing Arial fix explanation for Ubuntu to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,16 @@ verwendet.
 Einen Startpunkt zur Nutzung von [LaTeX][1] findest Du in unserer LEA Gruppe [Arbeiten mit LaTeX][7]. Sie steht allen
 Angehörigen der Hochschule offen.
 
+### Problembehandlung: Arial wird von luaotfload nicht gefunden.
+
+Unter Ubuntu 22.04:
+```
+sudo apt install ttf-mscorefonts-installer  # Installiert nötige Fonts
+cd /usr/share/fonts/truetype/msttcorefonts/ # Wechselt in das Font Verzeichnis
+luaotfload-tool -L                          # Sucht nach Fonts im aktuellen Verzeichnis
+luaotfload-tool -u                          # Updatet die Font Datenbank
+```
+
 ## Autoren
 
 ### 2020-20**


### PR DESCRIPTION
Hi Martin,
danke für die tolle Vorlage! Ich hatte Probleme damit, weil Arial nicht per default installiert war. Hier ist ein Vorschlag für die Readme, um das Problem auf Ubuntu zu beheben.